### PR TITLE
Remove the old remote feature (unused, fire-and-forget)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -174,8 +174,8 @@ func slave(c *cli.Context) {
 	//server := http.NewServeMux()
 
 	sub := r.PathPrefix(sc.ApiPrefix).Subrouter()
-	sub.HandleFunc("/ws/{app_key}", WsConnect(sc, publicPem, nc, rsHub)).Methods("GET")
-	sub.HandleFunc("/wtf/{app_key}", WsConnect(sc, publicPem, nc, rsHub)).Methods("GET")
+	sub.HandleFunc("/ws/{app_key}", WsConnect(sc, publicPem, rsHub)).Methods("GET")
+	sub.HandleFunc("/wtf/{app_key}", WsConnect(sc, publicPem, rsHub)).Methods("GET")
 	sub.HandleFunc("/auth", WsAuth(sc, publicPem)).Methods("POST")
 	sub.HandleFunc("/ping", Ping()).Methods("GET")
 	n := negroni.New()

--- a/slave_api.go
+++ b/slave_api.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/gorilla/mux"
-	nats "github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
 	"github.com/syhlion/redisocket.v2"
 )
@@ -55,7 +54,7 @@ func WsAuth(sc SlaveConfig, pubKey *rsa.PublicKey) http.HandlerFunc {
 
 // WsConnect 同時供 /ws 與 /wtf(原 WtfConnect 已併入,去除重複)。
 // token 參數即 JWT,本機 RSA 公鑰驗證 → auth,無 redis。
-func WsConnect(sc SlaveConfig, pubKey *rsa.PublicKey, nc *nats.Conn, rHub *redisocket.Hub) http.HandlerFunc {
+func WsConnect(sc SlaveConfig, pubKey *rsa.PublicKey, rHub *redisocket.Hub) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		appKey := params["app_key"]
@@ -91,7 +90,7 @@ func WsConnect(sc SlaveConfig, pubKey *rsa.PublicKey, nc *nats.Conn, rHub *redis
 			"user_id":   auth.UserId,
 		}).Info("connect")
 		s.Listen(func(data []byte) (b []byte, err error) {
-			h, err := CommanRouter(data, nc)
+			h, err := CommanRouter(data)
 			if err != nil {
 				logger.WithField("socket_id", s.SocketId()).WithError(err).Info("router error")
 				return
@@ -301,71 +300,6 @@ func PingPongCommand(appkey string, auth redisocket.Auth, data []byte, socketId 
 	msg.msg = reply
 	return
 }
-func Remote(nc *nats.Conn) func(string, redisocket.Auth, []byte, string, bool) (msg *commandResponse, err error) {
-	return func(appkey string, auth redisocket.Auth, data []byte, socketId string, debug bool) (msg *commandResponse, err error) {
-
-		remote, err := jsonparser.GetString(data, "remote")
-		if err != nil {
-			return
-		}
-		uid, err := jsonparser.GetString(data, "uid")
-		if err != nil {
-			return
-		}
-		payload, _, _, err := jsonparser.Get(data, "payload")
-		if err != nil {
-			return
-		}
-		p := JsonCheck(string(payload))
-		msg = &commandResponse{
-			cmdType: "REMOTE",
-		}
-		var reply []byte
-		command := &RemoteCommand{}
-		command.Data.Remote = remote
-		b, ok := auth.Remotes[remote]
-
-		//沒有這個remote 返回錯誤訊息不斷線
-		if !ok || !b {
-			command.Event = RemoteReplyError
-			command.SocketId = socketId
-			reply, err = json.Marshal(command)
-			if err != nil {
-				return
-			}
-			msg.msg = reply
-			return
-		}
-		wp := WorkerPayload{
-			UserId:   auth.UserId,
-			Data:     p,
-			Uid:      uid,
-			SocketId: socketId,
-			AppKey:   auth.AppKey,
-		}
-		d, err := json.Marshal(wp)
-		if err != nil {
-			return
-		}
-		// 發佈到 NATS rpc subject(取代 RPUSH redis;外部 worker 訂閱消費)
-		// subject:<prefix>rpc.<appKey>.<remote>,與 bus(ch.)/presence 命名空間分離
-		if err = nc.Publish(listenChannelPrefix+"rpc."+auth.AppKey+"."+remote, d); err != nil {
-			return
-		}
-		command.Event = RemoteReplySucceeded
-		command.SocketId = socketId
-		reply, err = json.Marshal(command)
-		if err != nil {
-			return
-		}
-		if debug {
-			msg.msg = reply
-		}
-
-		return
-	}
-
-}
 func UnSubscribeCommand(appkey string, auth redisocket.Auth, data []byte, socketId string, debug bool) (msg *commandResponse, err error) {
 	channel, err := jsonparser.GetString(data, "channel")
 	if err != nil {
@@ -420,15 +354,13 @@ func UnSubscribeCommand(appkey string, auth redisocket.Auth, data []byte, socket
 	return
 }
 
-func CommanRouter(data []byte, nc *nats.Conn) (fn func(appkey string, auth redisocket.Auth, data []byte, socketId string, debug bool) (msg *commandResponse, err error), err error) {
+func CommanRouter(data []byte) (fn func(appkey string, auth redisocket.Auth, data []byte, socketId string, debug bool) (msg *commandResponse, err error), err error) {
 
 	val, err := jsonparser.GetString(data, "event")
 	if err != nil {
 		return
 	}
 	switch val {
-	case RemoteEvent:
-		return Remote(nc), nil
 	case QueryChannelEvent:
 		return QueryChannelCommand, nil
 	case SubscribeEvent:

--- a/spec.go
+++ b/spec.go
@@ -13,13 +13,10 @@ const (
 	AddChannelEvent              = "gusher.addchannel"
 	ReloadChannelEvent           = "gusher.reloadchannel"
 	PongReplySucceeded           = "gusher.pong_succeeded"
-	RemoteEvent                  = "gusher.remote"
 	LoginEvent                   = "gusher.login"
 	SubscribeEvent               = "gusher.subscribe"
 	MultiSubscribeEvent          = "gusher.multi_subscribe"
 	UnSubscribeEvent             = "gusher.unsubscribe"
-	RemoteReplySucceeded         = "gusher.remote_succeeded"
-	RemoteReplyError             = "gusher.remote_error"
 	SubscribeReplySucceeded      = "gusher.subscribe_succeeded"
 	SubscribeReplyError          = "gusher.subscribe_error"
 	MultiSubscribeReplySucceeded = "gusher.multi_subscribe_succeeded"
@@ -38,20 +35,11 @@ type InternalCommand struct {
 	Event    string `json:"event"`
 	SocketId string `json:"socket_id"`
 }
-type RemoteCommand struct {
-	InternalCommand
-	Data RemoteData `json:"data"`
-}
-
 type ChannelInfoData struct {
 	InternalCommand
 	Data interface{} `json:"data"`
 }
 
-type RemoteData struct {
-	Remote string      `json:"remote"`
-	Msg    interface{} `json:"msg"`
-}
 type PingCommand struct {
 	InternalCommand
 	Data interface{} `json:"data"`
@@ -77,20 +65,4 @@ type ChannelData struct {
 type JwtPack struct {
 	Gusher redisocket.Auth `json:"gusher"`
 	jwt.StandardClaims
-}
-
-/*
-type Auth struct {
-	Channels []string        `json:"channels"`
-	UserId   string          `json:"user_id"`
-	AppKey   string          `json:"app_key"`
-	Remotes  map[string]bool `json:"remotes"`
-}
-*/
-type WorkerPayload struct {
-	UserId   string      `json:"user_id"`
-	SocketId string      `json:"socket_id"`
-	Uid      string      `json:"uid"`
-	AppKey   string      `json:"app_key"`
-	Data     interface{} `json:"data"`
 }


### PR DESCRIPTION
移除舊的 `remote` 功能——它是 fire-and-forget(client 送命令後拿不到回應、無遞送保證),且目前沒人在用。

## 移除內容
- `slave_api.go`:`Remote()`、CommanRouter 的 `RemoteEvent` 分支;CommanRouter / WsConnect 不再需要 `nats.Conn` 參數
- `spec.go`:`RemoteEvent` / `RemoteReplySucceeded` / `RemoteReplyError` 常數、`RemoteCommand` / `RemoteData` / `WorkerPayload` 結構

gusher 收斂為純粹的「授權 + 訂閱 + 推播」即時閘道。client→backend 通道未來若需要,改用更穩健的 **NATS request/reply**(有回應、queue group 可擴展、可選 JetStream 持久,全程零 redis)。

build `./...` + `go vet` 乾淨;subscribe / push 路徑不受影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)