### PR TITLE
release: v2.0.0 (NATS, no Redis) — pin engine v1.0.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,26 @@
 ## [Unreleased]
 
+## [v2.0.0] - 2026-06-25
+
+> **Breaking**: the backend is now NATS (no Redis); env and the `remote` feature
+> changed. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 ### [Changed]
 
 - **Migrate from Redis to NATS** — realtime bus (subject routing) and presence
   (per-node memory + request/reply) now run on NATS; **Redis is removed**.
 - **Local JWT auth** — verify the JWT with the RSA public key in-process; no
   decode service, no token store. The `/auth` → `/ws?token=` flow is unchanged.
-- Adopt the modernized `redisocket.v2` engine (slog logger; output
+- Adopt the modernized `redisocket.v2` v1.0.0 engine (slog logger; output
   stdout/file/both + log rotation via `GUSHER_LOG_*`).
-- pprof bound to localhost; `/ws` and `/wtf` share one handler.
+- NATS reconnect/creds support; `/ready` readiness probe; pprof bound to
+  localhost; `/ws` and `/wtf` share one handler.
 
 ### [Removed]
 
 - The `remote` feature (`gusher.remote`, fire-and-forget RPUSH) — unused. A
   future client→backend channel will use NATS request/reply.
 - All Redis env (`GUSHER_REDIS_*`, `GUSHER_JOB_REDIS_*`, `GUSHER_DECODE_SERVICE`).
-
-### [Fix]
 
 ## [v1.13.2]
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nats-io/nats.go v1.52.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/syhlion/httplog v0.0.0-20200804071957-8dddff4f795c
-	github.com/syhlion/redisocket.v2 v0.0.0-20260624092217-c4652be98cb8
+	github.com/syhlion/redisocket.v2 v1.0.0
 	github.com/urfave/cli v1.22.10
 	github.com/urfave/negroni v1.0.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syhlion/httplog v0.0.0-20200804071957-8dddff4f795c h1:DtKj4QaLQmFWR1i5rPsTd4O+cvon5gj1JvZ2TFEzq8w=
 github.com/syhlion/httplog v0.0.0-20200804071957-8dddff4f795c/go.mod h1:HcK3bo5i1PHBX5gsd1pwkFiNLrYtLlmGD6ADDL60Zoc=
-github.com/syhlion/redisocket.v2 v0.0.0-20260624092217-c4652be98cb8 h1:D+EOUfwhHkdWaQt28Y2mjjiWqP1vbhYy2EuNDQsezPQ=
-github.com/syhlion/redisocket.v2 v0.0.0-20260624092217-c4652be98cb8/go.mod h1:hRHOtJ1BlRNXkaMVeMW8kZvUiCU4agFawkGk2BWeFbY=
+github.com/syhlion/redisocket.v2 v1.0.0 h1:7RSIiqqgYTfNhxujr7bqjzZ6DcDl/xc9vX0irEPJnBc=
+github.com/syhlion/redisocket.v2 v1.0.0/go.mod h1:hRHOtJ1BlRNXkaMVeMW8kZvUiCU4agFawkGk2BWeFbY=
 github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=

--- a/vendor/github.com/syhlion/redisocket.v2/.drone.yml
+++ b/vendor/github.com/syhlion/redisocket.v2/.drone.yml
@@ -1,0 +1,9 @@
+kind: pipeline
+name: default
+
+steps:
+- name: test
+  image: golang:1.25
+  commands:
+  - go vet ./...
+  - go test -race -count=1 ./...

--- a/vendor/github.com/syhlion/redisocket.v2/.travis.yml
+++ b/vendor/github.com/syhlion/redisocket.v2/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-
-go :
-    - 1.7
-    - 1.8
-    - tip
-script:
-    - go build

--- a/vendor/github.com/syhlion/redisocket.v2/README.md
+++ b/vendor/github.com/syhlion/redisocket.v2/README.md
@@ -1,59 +1,71 @@
 # redisocket.v2
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/syhlion/redisocket.v2)](https://goreportcard.com/report/github.com/syhlion/redisocket.v2)
-[![Build Status](https://travis-ci.org/syhlion/redisocket.v2.svg?branch=master)](https://travis-ci.org/syhlion/redisocket.v2)
 
-Base on gorilla/websocket & garyburd/redigo
+A WebSocket **hub engine**: it holds ws connections and fans out messages across
+nodes, with the cross-node **bus** and **presence** behind pluggable interfaces.
+Pick a **Redis** or **NATS** backend — swapping it never touches the connection
+layer. (This is the engine behind [gusher.cluster](https://github.com/syhlion/gusher.cluster).)
 
-Implement By Observer pattern
-
-## Documention
-
-* [API Reference](https://godoc.org/github.com/syhlion/redisocket.v2)
+📐 **Architecture**: [English](docs/ARCHITECTURE.md) · [繁體中文](docs/ARCHITECTURE.zh-TW.md)
 
 ## Install
 
-`go get github.com/syhlion/redisocket.v2`
-
-## Usaged
-
-``` go
-func TestEvent(d []byte) (data []byte, err error) {
-	return d, nil
-}
-
-func main() {
-	pool := redis.NewPool(func() (redis.Conn, error) {
-		return redis.Dial("tcp", ":6379")
-	}, 10)
-	app := redisocket.NewHub(pool,false)
-
-	err := make(chan error)
-	go func() {
-		err <- app.Listen()
-	}()
-
-	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-
-        client,err:= app.Upgrade(w, r, nil, "Scott", "appKey")
-		if err != nil {
-			log.Fatal("Client Connect Error")
-			return
-		}
-		err = client.Listen(func(data []byte) (d []byte, err error) {
-			return data,nil
-
-		})
-		log.Println(err, "http point")
-		return
-	})
-
-	go func() {
-		err <- http.ListenAndServe(":8888", nil)
-	}()
-	select {
-	case e := <-err:
-		log.Println(e)
-	}
-}
+```sh
+go get github.com/syhlion/redisocket.v2
 ```
+
+## Usage
+
+The engine takes a `*slog.Logger` (output is the caller's choice). Pick a backend
+when you build the hub:
+
+```go
+// NATS backend (bus + per-node presence; no Redis)
+nc, _ := nats.Connect("nats://127.0.0.1:4222")
+broker := redisocket.NewNATSBroker(nc)
+presence, _ := redisocket.NewMemoryPresence(nc, "app.")
+hub := redisocket.NewHubWithBrokerAndPresence(broker, presence, slog.Default(), false)
+
+// — or — Redis backend
+// pool := &redis.Pool{ Dial: func() (redis.Conn, error) { return redis.Dial("tcp", ":6379") } }
+// hub := redisocket.NewHub(pool, slog.Default(), false)
+
+go hub.Listen("app.") // channelPrefix; blocks
+defer hub.Close()     // graceful shutdown (goleak-clean)
+
+http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+	auth := &redisocket.Auth{AppKey: "appKey", UserId: "Scott", Channels: []string{"*"}}
+	c, err := hub.Upgrade(w, r, nil, auth.UserId, auth.AppKey, auth)
+	if err != nil {
+		return
+	}
+	c.Listen(func(data []byte) (resp []byte, err error) {
+		// handle an inbound client message; return bytes to echo back
+		return nil, nil
+	})
+})
+```
+
+Publish into a channel from anywhere (e.g. a separate publish API node):
+
+```go
+sender := redisocket.NewSenderWithBrokerAndPresence(broker, presence) // NATS
+// sender := redisocket.NewSender(pool)                               // Redis
+sender.Push("app.", "appKey", "AA", []byte(`{"hello":"world"}`))      // → subscribers of channel AA
+```
+
+## Configurable logger (optional)
+
+```go
+lg, closeLog, _ := redisocket.NewLogger(redisocket.LogConfig{
+	Output: redisocket.LogBoth, File: "/var/log/app.log", // stdout / file / both
+	Format: "json", MaxSizeMB: 100, MaxBackups: 7, Compress: true, // logrotate
+})
+defer closeLog()
+```
+
+## Docs
+
+- [Architecture](docs/ARCHITECTURE.md) — engine internals, Broker / Presence, graceful shutdown, testing
+- [API Reference](https://pkg.go.dev/github.com/syhlion/redisocket.v2)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,7 +66,7 @@ github.com/sirupsen/logrus
 # github.com/syhlion/httplog v0.0.0-20200804071957-8dddff4f795c
 ## explicit
 github.com/syhlion/httplog
-# github.com/syhlion/redisocket.v2 v0.0.0-20260624092217-c4652be98cb8
+# github.com/syhlion/redisocket.v2 v1.0.0
 ## explicit; go 1.25.0
 github.com/syhlion/redisocket.v2
 # github.com/urfave/cli v1.22.10


### PR DESCRIPTION
Breaking release v2.0.0:NATS 後端(無 Redis)、env 變更、remote 移除。pin redisocket.v2 v1.0.0、收 CHANGELOG。

🤖 Generated with [Claude Code](https://claude.com/claude-code)