### PR TITLE
test(smoke): add `make smoke` — compose-stack e2e with exit codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ build/darwin_amd64.tar.gz: build/darwin
 	$(call tar,darwin,amd64,)
 clean:
 	rm -rf build/
+smoke:
+	./scripts/smoke.sh
 docker-build:
 	$(call dockerbuild,linux,amd64,)
 rsakey:

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# smoke.sh — bring up the docker-compose stack (nats + master + slave, no
+# Redis), run the assertive smoke client against it, and tear it down. Exits
+# non-zero if the stack never becomes ready or the smoke check fails.
+#
+# Usage: make smoke   (or: scripts/smoke.sh)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE="docker compose -f docker-compose/docker-compose.yml"
+MASTER_PING="http://127.0.0.1:7777/ping"
+SLAVE_PING="http://127.0.0.1:8888/ping"
+
+cleanup() {
+  echo "--- tearing down stack ---"
+  $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# the stack mounts docker-compose/public.pem (tracked in the repo, matching
+# test/key/private.pem) to verify the smoke JWT signed below.
+if [ ! -f docker-compose/public.pem ]; then
+  echo "ERROR: docker-compose/public.pem missing (expected to be tracked in repo)"
+  exit 1
+fi
+
+echo "--- building + starting stack ---"
+$COMPOSE up -d --build
+
+wait_ready() {
+  local url="$1" name="$2" i
+  for i in $(seq 1 60); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      echo "$name ready"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: $name not ready after 60s"
+  $COMPOSE logs --tail=50 || true
+  return 1
+}
+wait_ready "$MASTER_PING" master
+wait_ready "$SLAVE_PING" slave
+
+echo "--- generating JWT ---"
+go build -o "$ROOT/build/jwt-generate" test/jwtgenerate/jwtgenerate.go
+TOKEN="$("$ROOT/build/jwt-generate" gen --private-key test/key/private.pem 2>/dev/null | grep -oE 'eyJ[A-Za-z0-9_.-]+' | head -1)"
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: failed to generate JWT"
+  exit 1
+fi
+
+echo "--- running smoke client ---"
+SMOKE_JWT="$TOKEN" \
+SMOKE_AUTH_URL="http://127.0.0.1:8888/auth" \
+SMOKE_WS_URL="ws://127.0.0.1:8888/ws/TEST" \
+SMOKE_PUSH_URL="http://127.0.0.1:7777/push/TEST/AA/EVENT" \
+SMOKE_CONNECTIONS="${SMOKE_CONNECTIONS:-50}" \
+  go run test/smoke/smoke.go
+
+echo "--- smoke ok ---"

--- a/test/smoke/smoke.go
+++ b/test/smoke/smoke.go
@@ -1,0 +1,124 @@
+// Command smoke is a correctness check against a running gusher.cluster stack
+// (see docker-compose). It drives the full path — auth -> ws connect ->
+// subscribe -> master push -> receive — across N connections and exits
+// non-zero if any connection fails to receive the pushed message. Unlike
+// test/conn-test (a load/latency tool that only logs), this returns a proper
+// exit code so it can gate `make smoke` / CI.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	var (
+		authURL = env("SMOKE_AUTH_URL", "http://127.0.0.1:8888/auth")
+		wsURL   = env("SMOKE_WS_URL", "ws://127.0.0.1:8888/ws/TEST")
+		pushURL = env("SMOKE_PUSH_URL", "http://127.0.0.1:7777/push/TEST/AA/EVENT")
+		jwt     = os.Getenv("SMOKE_JWT")
+		subMsg  = env("SMOKE_SUBSCRIBE", `{"event":"gusher.subscribe","data":{"channel":"AA"}}`)
+		payload = env("SMOKE_PAYLOAD", "hello-smoke")
+	)
+	conns, _ := strconv.Atoi(env("SMOKE_CONNECTIONS", "50"))
+	if conns < 1 {
+		conns = 1
+	}
+	if jwt == "" {
+		fatal("SMOKE_JWT is empty")
+	}
+
+	// 1) /auth — local JWT verify
+	resp, err := http.PostForm(authURL, url.Values{"jwt": {jwt}})
+	if err != nil {
+		fatal("auth request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fatal("auth status = %d, want 200", resp.StatusCode)
+	}
+	log.Printf("auth ok; opening %d connections", conns)
+
+	// 2) open N ws connections and subscribe
+	dialURL := wsURL + "?token=" + jwt
+	clients := make([]*websocket.Conn, 0, conns)
+	for i := 0; i < conns; i++ {
+		c, _, err := websocket.DefaultDialer.Dial(dialURL, nil)
+		if err != nil {
+			fatal("ws dial #%d: %v", i, err)
+		}
+		c.SetWriteDeadline(time.Now().Add(10 * time.Second))
+		if err := c.WriteMessage(websocket.TextMessage, []byte(subMsg)); err != nil {
+			fatal("subscribe write #%d: %v", i, err)
+		}
+		c.SetReadDeadline(time.Now().Add(10 * time.Second))
+		if _, reply, err := c.ReadMessage(); err != nil {
+			fatal("subscribe reply #%d: %v", i, err)
+		} else if !strings.Contains(string(reply), "subscribe_succeeded") {
+			fatal("subscribe #%d not succeeded: %s", i, reply)
+		}
+		clients = append(clients, c)
+	}
+	log.Printf("all %d subscribed; pushing", conns)
+
+	// 3) every client waits for the pushed message
+	var received int64
+	var wg sync.WaitGroup
+	for i, c := range clients {
+		wg.Add(1)
+		go func(i int, c *websocket.Conn) {
+			defer wg.Done()
+			defer c.Close()
+			c.SetReadDeadline(time.Now().Add(15 * time.Second))
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				log.Printf("client #%d read: %v", i, err)
+				return
+			}
+			if strings.Contains(string(msg), payload) {
+				atomic.AddInt64(&received, 1)
+			} else {
+				log.Printf("client #%d unexpected message: %s", i, msg)
+			}
+		}(i, c)
+	}
+
+	// 4) master push (once) — fan-out to all subscribers
+	pResp, err := http.PostForm(pushURL, url.Values{"data": {payload}})
+	if err != nil {
+		fatal("push request: %v", err)
+	}
+	pResp.Body.Close()
+	if pResp.StatusCode != http.StatusOK {
+		fatal("push status = %d, want 200", pResp.StatusCode)
+	}
+
+	wg.Wait()
+	got := atomic.LoadInt64(&received)
+	if int(got) != conns {
+		fatal("only %d/%d clients received the message", got, conns)
+	}
+	log.Printf("SMOKE PASS: %d/%d clients received the pushed message", got, conns)
+}
+
+func fatal(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "SMOKE FAIL: "+format+"\n", a...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## What
`test/conn-test` only **logs** its result (no exit code), so it can't gate a release or CI. This adds an assertive **`make smoke`** that runs the full path against a real docker-compose stack and fails loudly on any miss.

## Changes
- **`test/smoke/smoke.go`** — env-driven client: `/auth` → ws connect → subscribe → master `/push` → receive, across N connections (default 50). Exits **non-zero** unless every client receives the pushed message (vs conn-test which only prints).
- **`scripts/smoke.sh`** — `docker compose up -d --build` (nats + master + slave, **no Redis**), waits for master/slave `/ping`, generates a JWT via `jwtgenerate` signed with `test/key/private.pem` (the stack mounts the matching tracked `docker-compose/public.pem`), runs the smoke client, then tears the stack down via an `EXIT` trap.
- **`Makefile`** — `make smoke` target.

## Where it fits
- In-process `go test` e2e (PR #22) → fast, runs every commit in CI.
- `make smoke` (this) → real containers, end-to-end, for pre-release confidence. Heavier, run on demand.
- `test/loadtest` → perf/latency baseline, unchanged.

## Verification
Ran `make smoke` locally: builds images, **30/30 connections received the pushed message**, stack torn down cleanly; tracked `docker-compose/public.pem` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)