### PR TITLE
chore: drop committed loadtest binary, doc /ready endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ jwt-generate
 glide.lock
 test/conn-test/conn-test
 
+loadtest

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ jwt-generate
 glide.lock
 test/conn-test/conn-test
 
-loadtest
+/loadtest

--- a/doc/api.md
+++ b/doc/api.md
@@ -32,6 +32,12 @@ Success Response:
 pong
 ```
 
+### Ready:
+
+`GET /{prefix}/ready`
+
+Readiness probe — `200 ready` when NATS is connected, `503 nats not connected` otherwise.
+
 ## Master Api
 
 
@@ -271,6 +277,12 @@ Success Response:
 ```
 pong
 ```
+
+### Ready:
+
+`GET /{prefix}/ready`
+
+Readiness probe — `200 ready` when NATS is connected, `503 nats not connected` otherwise.
 
 * note1: if channels slice have "*" char that user can sub all channels
 * note2: support *  like test = t*st or app* = apple


### PR DESCRIPTION
## What

Post-v2.0.0 cleanup of two loose ends found while reviewing the NATS migration.

- **Remove the committed `loadtest` binary (8.2MB).** A compiled ELF was accidentally committed in #18; the source already lives at `test/loadtest/loadtest.go`. `git rm --cached` it and add `loadtest` to `.gitignore` (which already ignored `gusher.cluster` / `build/` but not this).
- **Document the `/ready` readiness probe** in `doc/api.md` for both master and slave — `200 ready` when NATS is connected, `503 nats not connected` otherwise. It was added in the NATS migration but never written up.

## Verification

- `go build ./...` ✅
- `make smoke` ✅ — compose stack (nats + master + slave, no Redis), 50/50 clients received the pushed message
- Audited `doc/api.md` endpoints against the actual routes in `cmd.go`: all match (kept `doc/`, it's the accurate REST/WS reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)