### PR TITLE
docs: unify README style with gua

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Gusher.Cluster
 
 [![Build Status](https://drone.syhlion.tw/api/badges/syhlion/gusher.cluster/status.svg)](https://drone.syhlion.tw/syhlion/gusher.cluster)
- [![Stars](https://img.shields.io/github/stars/syhlion/gusher.cluster.svg)](https://github.com/syhlion/gusher.cluster)
- [![Go](https://img.shields.io/github/go-mod/go-version/syhlion/gusher.cluster.svg)](go.mod)
- [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
- [![Backed by NATS](https://img.shields.io/badge/backed%20by-NATS-27AAE1.svg)](https://nats.io)
- [![docs English](https://img.shields.io/badge/docs-English-blue.svg)](README.md)
- [![docs 繁體中文](https://img.shields.io/badge/docs-%E7%B9%81%E9%AB%94%E4%B8%AD%E6%96%87-lightgrey.svg)](README.zh-TW.md)
+[![Stars](https://img.shields.io/github/stars/syhlion/gusher.cluster.svg)](https://github.com/syhlion/gusher.cluster)
+[![Go](https://img.shields.io/github/go-mod/go-version/syhlion/gusher.cluster.svg)](go.mod)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Backed by NATS](https://img.shields.io/badge/backed%20by-NATS-27AAE1.svg)](https://nats.io)
+[![docs English](https://img.shields.io/badge/docs-English-blue.svg)](README.md)
+[![docs 繁體中文](https://img.shields.io/badge/docs-%E7%B9%81%E9%AB%94%E4%B8%AD%E6%96%87-lightgrey.svg)](README.zh-TW.md)
 
 Self-hosted realtime push service (Pusher-style). Browsers hold a **WebSocket**
 and subscribe to channels; backends **POST** to push a message into a channel.
 Horizontally scalable, **backed by NATS — no Redis**.
 
-📐 **Architecture**: [English](docs/ARCHITECTURE.md) · [繁體中文](docs/ARCHITECTURE.zh-TW.md)
+## Architecture
 
-## How it works
+![system](docs/diagrams/system.drawio.png)
 
-- **slave** — holds the WebSocket connections, verifies the JWT locally, and
-  fans out messages to subscribers.
+- **slave** — holds the WebSocket connections, verifies the JWT locally (RSA
+  public key), and fans out messages to subscribers.
 - **master** — a stateless REST API to **push** messages and **query** presence.
 - **NATS** — carries messages between nodes (bus) and answers presence queries
   (request/reply). No Redis, no token store, no decode service.
@@ -26,17 +26,18 @@ Horizontally scalable, **backed by NATS — no Redis**.
 client ──ws──▶ slave ──subscribe──▶  NATS  ◀──publish── master ◀──POST── backend
 ```
 
+Both roles are stateless and scale horizontally. Full write-up (bus, presence,
+evolution from Redis) in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 ## Requirements
 
-- **NATS** (the only backend) — `nats-server` 2.10+
+- **NATS** (the only backend) — `nats-server` 2.10+.
 - An **RSA key pair** — master/slave verify the JWT with the **public key**;
   your own auth service signs JWTs with the private key. See
   [docs/KEYS.md](docs/KEYS.md) for the full generate → sign → verify → rotate
   walkthrough.
 
-## Run
-
-### docker-compose (quickest)
+## Quick start (Docker Compose)
 
 Put your `public.pem` next to the compose file, then:
 
@@ -46,7 +47,7 @@ docker compose -f docker-compose/docker-compose.yml up --build
 
 Brings up `nats` + `gusher-master` (`:7777`) + `gusher-slave` (`:8888`), no Redis.
 
-### From source
+## Run (from source)
 
 ```sh
 go build -ldflags "-X main.name=gusher" -o gusher.cluster .
@@ -62,13 +63,6 @@ GUSHER_MASTER_API_LISTEN=:7777 GUSHER_MASTER_URI_PREFIX=/ ./gusher.cluster maste
 
 See `slave.env.example` / `master.env.example` for the full env list.
 
-## Ops
-
-- **Health**: `GET /ping` (liveness) · `GET /ready` (readiness — 200 only while
-  NATS is connected).
-- **NATS auth**: set `GUSHER_NATS_CREDS=/path/to/app.creds` for user credentials;
-  use a `tls://` address (or NATS server config) for TLS. The client auto-reconnects.
-
 ## Client flow
 
 1. `POST /auth` with `jwt=<JWT>` → `{"token":"<JWT>"}` (the JWT is verified
@@ -81,6 +75,13 @@ The JWT carries the `gusher` claim — `{"app_key","user_id","channels"}` — si
 **RS256**. See [doc/protocal.md](./doc/protocal.md) for the full WebSocket
 protocol and [doc/api.md](./doc/api.md) for the REST API.
 
+## Ops
+
+- **Health**: `GET /ping` (liveness) · `GET /ready` (readiness — 200 only while
+  NATS is connected).
+- **NATS auth**: set `GUSHER_NATS_CREDS=/path/to/app.creds` for user credentials;
+  use a `tls://` address (or NATS server config) for TLS. The client auto-reconnects.
+
 ## Logging
 
 Output is selectable and rotated, via env:
@@ -91,3 +92,17 @@ Output is selectable and rotated, via env:
 | `GUSHER_LOG_FILE` | path (for `file` / `both`) |
 | `GUSHER_LOG_FORMAT` | `json` (default) / `text` |
 | `GUSHER_LOG_MAX_SIZE_MB` / `_MAX_BACKUPS` / `_MAX_AGE_DAYS` / `_COMPRESS` | rotation |
+
+## Docs
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — architecture, NATS bus/presence, evolution from Redis (with diagrams)
+- [doc/protocal.md](./doc/protocal.md) — WebSocket protocol
+- [doc/api.md](./doc/api.md) — REST API
+- [docs/KEYS.md](docs/KEYS.md) — RSA keys: generate → sign → verify → rotate
+- [docs/LOAD-TEST.md](docs/LOAD-TEST.md) — load testing
+
+## Tests
+
+```
+go test ./...     # unit + e2e (e2e spins up an in-process NATS, no external deps)
+```

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,21 +1,21 @@
 # Gusher.Cluster
 
 [![Build Status](https://drone.syhlion.tw/api/badges/syhlion/gusher.cluster/status.svg)](https://drone.syhlion.tw/syhlion/gusher.cluster)
- [![Stars](https://img.shields.io/github/stars/syhlion/gusher.cluster.svg)](https://github.com/syhlion/gusher.cluster)
- [![Go](https://img.shields.io/github/go-mod/go-version/syhlion/gusher.cluster.svg)](go.mod)
- [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
- [![Backed by NATS](https://img.shields.io/badge/backed%20by-NATS-27AAE1.svg)](https://nats.io)
- [![docs English](https://img.shields.io/badge/docs-English-lightgrey.svg)](README.md)
- [![docs 繁體中文](https://img.shields.io/badge/docs-%E7%B9%81%E9%AB%94%E4%B8%AD%E6%96%87-blue.svg)](README.zh-TW.md)
+[![Stars](https://img.shields.io/github/stars/syhlion/gusher.cluster.svg)](https://github.com/syhlion/gusher.cluster)
+[![Go](https://img.shields.io/github/go-mod/go-version/syhlion/gusher.cluster.svg)](go.mod)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Backed by NATS](https://img.shields.io/badge/backed%20by-NATS-27AAE1.svg)](https://nats.io)
+[![docs English](https://img.shields.io/badge/docs-English-lightgrey.svg)](README.md)
+[![docs 繁體中文](https://img.shields.io/badge/docs-%E7%B9%81%E9%AB%94%E4%B8%AD%E6%96%87-blue.svg)](README.zh-TW.md)
 
 自架的即時推播服務（仿 Pusher 風格）。瀏覽器以 **WebSocket** 連線並訂閱頻道；
 後端則 **POST** 把訊息推進頻道。可水平擴展，**以 NATS 為後端——不需要 Redis**。
 
-📐 **架構文件**：[English](docs/ARCHITECTURE.md) · [繁體中文](docs/ARCHITECTURE.zh-TW.md)
+## 架構
 
-## 運作原理
+![system](docs/diagrams/system.drawio.png)
 
-- **slave**——持有 WebSocket 連線，在本地驗證 JWT，並把訊息扇出給訂閱者。
+- **slave**——持有 WebSocket 連線，在本地以 RSA 公鑰驗證 JWT，並把訊息扇出給訂閱者。
 - **master**——無狀態的 REST API，用來**推播**訊息與**查詢**在線狀態（presence）。
 - **NATS**——在節點之間傳遞訊息（匯流排），並以 request/reply 回答 presence 查詢。
   沒有 Redis、沒有 token store、沒有 decode 服務。
@@ -24,15 +24,16 @@
 client ──ws──▶ slave ──subscribe──▶  NATS  ◀──publish── master ◀──POST── backend
 ```
 
+兩種角色都是無狀態且可水平擴展。完整說明（匯流排、presence、從 Redis 的演進）見
+[docs/ARCHITECTURE.zh-TW.md](docs/ARCHITECTURE.zh-TW.md)。
+
 ## 環境需求
 
 - **NATS**（唯一的後端）——`nats-server` 2.10 以上。
 - 一組 **RSA 金鑰對**——master/slave 以**公鑰**驗證 JWT；由你自己的認證服務以私鑰簽發 JWT。
   完整的「產生 → 簽 → 驗證 → 輪替」教學見 [docs/KEYS.zh-TW.md](docs/KEYS.zh-TW.md)。
 
-## 執行方式
-
-### docker-compose（最快）
+## 快速開始（Docker Compose）
 
 把你的 `public.pem` 放到 compose 檔旁邊，然後：
 
@@ -42,7 +43,7 @@ docker compose -f docker-compose/docker-compose.yml up --build
 
 會起 `nats` + `gusher-master`（`:7777`）+ `gusher-slave`（`:8888`），不含 Redis。
 
-### 從原始碼編譯
+## 執行方式（從原始碼編譯）
 
 ```sh
 go build -ldflags "-X main.name=gusher" -o gusher.cluster .
@@ -58,13 +59,6 @@ GUSHER_MASTER_API_LISTEN=:7777 GUSHER_MASTER_URI_PREFIX=/ ./gusher.cluster maste
 
 完整環境變數清單見 `slave.env.example` / `master.env.example`。
 
-## 維運
-
-- **健康檢查**：`GET /ping`（liveness）· `GET /ready`（readiness——只有在 NATS
-  連線正常時才回 200）。
-- **NATS 認證**：設定 `GUSHER_NATS_CREDS=/path/to/app.creds` 使用 user credentials；
-  TLS 則用 `tls://` 位址（或在 NATS server 設定）。client 會自動重連。
-
 ## 客端流程
 
 1. `POST /auth` 帶 `jwt=<JWT>` → `{"token":"<JWT>"}`（JWT 在本地驗證後直接當 token
@@ -77,6 +71,13 @@ JWT 帶有 `gusher` claim——`{"app_key","user_id","channels"}`——以 **RS2
 完整 WebSocket 協定見 [doc/protocal.md](./doc/protocal.md)，REST API 見
 [doc/api.md](./doc/api.md)。
 
+## 維運
+
+- **健康檢查**：`GET /ping`（liveness）· `GET /ready`（readiness——只有在 NATS
+  連線正常時才回 200）。
+- **NATS 認證**：設定 `GUSHER_NATS_CREDS=/path/to/app.creds` 使用 user credentials；
+  TLS 則用 `tls://` 位址（或在 NATS server 設定）。client 會自動重連。
+
 ## 日誌
 
 輸出方式可選，並支援輪替（rotation），透過環境變數設定：
@@ -87,3 +88,17 @@ JWT 帶有 `gusher` claim——`{"app_key","user_id","channels"}`——以 **RS2
 | `GUSHER_LOG_FILE` | 路徑（用於 `file` / `both`） |
 | `GUSHER_LOG_FORMAT` | `json`（預設）/ `text` |
 | `GUSHER_LOG_MAX_SIZE_MB` / `_MAX_BACKUPS` / `_MAX_AGE_DAYS` / `_COMPRESS` | 輪替設定 |
+
+## 文件
+
+- [docs/ARCHITECTURE.zh-TW.md](docs/ARCHITECTURE.zh-TW.md) — 架構、NATS 匯流排/presence、從 Redis 的演進（含圖）
+- [doc/protocal.md](./doc/protocal.md) — WebSocket 協定
+- [doc/api.md](./doc/api.md) — REST API
+- [docs/KEYS.zh-TW.md](docs/KEYS.zh-TW.md) — RSA 金鑰：產生 → 簽 → 驗證 → 輪替
+- [docs/LOAD-TEST.zh-TW.md](docs/LOAD-TEST.zh-TW.md) — 壓力測試
+
+## 測試
+
+```
+go test ./...     # 單元 + e2e（e2e 會在行程內起一顆 NATS，不需外部依賴）
+```


### PR DESCRIPTION
Aligns gusher.cluster's README with gua's so the two repos share one style.

## Changes
- **Architecture**: embed the system diagram inline (was link-only), with component bullets + ASCII flow + link to the full doc
- **Docs**: add a Docs list section (ARCHITECTURE / protocal / api / KEYS / LOAD-TEST)
- **Tests**: add a Tests section (`go test ./...`, e2e uses in-process NATS)
- **Badges**: normalize to one-per-line, blue MIT

zh-TW kept in lockstep with the English README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)