### PR TITLE
feat(api): global observability endpoints GET /v1/stats and /v1/apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### [Added]
+
+- **Global observability endpoints** (master): `GET /v1/stats` (totals across all
+  apps) and `GET /v1/apps` (per-app breakdown), each reporting **connections**
+  (exact — summed sockets) and **users** (approximate — summed per-node distinct
+  uids). Backed by the new `redisocket.v2` `Stats` scatter-gather (bumped to
+  v1.1.0). Counts refresh on each presence sync (`GUSHER_SCAN_INTERVAL`, default 30s).
+
 ### [Changed / API]
 
 - **HTTP API redesigned to a clean resource-oriented REST shape** and moved off

--- a/api.go
+++ b/api.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"net/http"
 	"regexp"
+	"sort"
 
 	redisocket "github.com/syhlion/redisocket.v2"
 )
@@ -331,6 +332,53 @@ func PushMessage(rsender *redisocket.Sender) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 		w.WriteHeader(http.StatusOK)
 		w.Write(d)
+	}
+}
+
+// GET /v1/stats — global totals across all apps (connections exact, users approx).
+func GetGlobalStats(rsender *redisocket.Sender) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		stats, err := rsender.GetStats(listenChannelPrefix)
+		if err != nil {
+			logger.GetRequestEntry(r).WithError(err).Warn("get stats error")
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("get stats error"))
+			return
+		}
+		var conns, users int
+		for _, s := range stats {
+			conns += s.Conns
+			users += s.Users
+		}
+		writeJSON(w, r, struct {
+			Apps        int `json:"apps"`
+			Connections int `json:"connections"`
+			Users       int `json:"users"`
+		}{Apps: len(stats), Connections: conns, Users: users})
+	}
+}
+
+// GET /v1/apps — per-app breakdown (connections exact, users approx), sorted by app.
+func GetApps(rsender *redisocket.Sender) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		stats, err := rsender.GetStats(listenChannelPrefix)
+		if err != nil {
+			logger.GetRequestEntry(r).WithError(err).Warn("get stats error")
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("get stats error"))
+			return
+		}
+		type appRow struct {
+			App         string `json:"app"`
+			Connections int    `json:"connections"`
+			Users       int    `json:"users"`
+		}
+		rows := make([]appRow, 0, len(stats))
+		for app, s := range stats {
+			rows = append(rows, appRow{App: app, Connections: s.Conns, Users: s.Users})
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].App < rows[j].App })
+		writeJSON(w, r, rows)
 	}
 }
 

--- a/cmd.go
+++ b/cmd.go
@@ -66,6 +66,10 @@ func master(c *cli.Context) {
 	r.HandleFunc("GET /readyz", Ready(nc))
 	r.HandleFunc("GET /version", Version(mc.Version))
 
+	// global observability (across all apps)
+	r.HandleFunc("GET /v1/stats", GetGlobalStats(rsender))
+	r.HandleFunc("GET /v1/apps", GetApps(rsender))
+
 	// publish
 	r.HandleFunc("POST /v1/apps/{app}/channels/{channel}/messages", PushMessage(rsender))
 	r.HandleFunc("POST /v1/apps/{app}/messages", PushMessageByPattern(rsender))

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/nats-io/nats-server/v2 v2.14.2
 	github.com/nats-io/nats.go v1.52.0
-	github.com/syhlion/redisocket.v2 v1.0.1
+	github.com/syhlion/redisocket.v2 v1.1.0
 	github.com/urfave/cli v1.22.10
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syhlion/redisocket.v2 v1.0.1 h1:BUt+xaGdhjccufSWocnB2zCf6iLf4vq1VZtqXdv7I88=
 github.com/syhlion/redisocket.v2 v1.0.1/go.mod h1:R5v23aI9k2C/VTqNqm/1dfl4i8ZGYikgoRp/bXTYoGw=
+github.com/syhlion/redisocket.v2 v1.1.0 h1:6+lno+zsVNilhpA40zg18Z6T3krvkrKrVcqtKgtSpLA=
+github.com/syhlion/redisocket.v2 v1.1.0/go.mod h1:R5v23aI9k2C/VTqNqm/1dfl4i8ZGYikgoRp/bXTYoGw=
 github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/vendor/github.com/syhlion/redisocket.v2/hub.go
+++ b/vendor/github.com/syhlion/redisocket.v2/hub.go
@@ -120,6 +120,13 @@ func (s *Sender) GetOnline(channelPrefix string, appKey string) (online []string
 	return s.presence.Online(channelPrefix, appKey)
 }
 
+// GetStats returns per-app connection (socket) + distinct-user counts across all
+// nodes. Connection counts are exact; user counts are an approximate sum (a user
+// connected to multiple nodes is counted once per node).
+func (s *Sender) GetStats(channelPrefix string) (map[string]AppStat, error) {
+	return s.presence.Stats(channelPrefix)
+}
+
 // PushBatch push batch data
 func (s *Sender) PushBatch(channelPrefix, appKey string, data []BatchData) {
 	for _, d := range data {

--- a/vendor/github.com/syhlion/redisocket.v2/memory_presence.go
+++ b/vendor/github.com/syhlion/redisocket.v2/memory_presence.go
@@ -25,18 +25,27 @@ type memoryPresence struct {
 	online map[string]map[string]struct{}
 	// appKey -> channel -> set(uid)
 	channels map[string]map[string]map[string]struct{}
+	// appKey -> connection (socket) count on this node, refreshed on Sync.
+	// Unlike online (deduped by uid), this counts every socket, so summing it
+	// across nodes is exact.
+	conns map[string]int
 }
 
 // presenceQuery / presenceReply 是跨節點查詢的 envelope(走 NATS request/reply)。
 type presenceQuery struct {
-	Type    string `json:"t"` // online | channel | channels
+	Type    string `json:"t"` // online | channel | channels | stats
 	AppKey  string `json:"a"`
 	Channel string `json:"c"`
 	Pattern string `json:"p"`
 }
+type appStatWire struct {
+	Conns int `json:"n"`
+	Users int `json:"u"`
+}
 type presenceReply struct {
-	Uids     []string `json:"u,omitempty"`
-	Channels []string `json:"c,omitempty"`
+	Uids     []string               `json:"u,omitempty"`
+	Channels []string               `json:"c,omitempty"`
+	Stats    map[string]appStatWire `json:"s,omitempty"`
 }
 
 const defaultPresenceQueryTimeout = 100 * time.Millisecond
@@ -49,6 +58,7 @@ func NewMemoryPresence(nc *nats.Conn, prefix string) (Presence, error) {
 		queryTimeout: defaultPresenceQueryTimeout,
 		online:       make(map[string]map[string]struct{}),
 		channels:     make(map[string]map[string]map[string]struct{}),
+		conns:        make(map[string]int),
 	}
 	// 每個節點都訂閱查詢主題,回覆自己本機的成員。用 queue group 之外的純 fan-out:
 	// 不設 queue,故所有節點都會收到並回覆(scatter-gather)。
@@ -82,8 +92,11 @@ func (p *memoryPresence) Sync(prefix string, members []PresenceMember) error {
 	defer p.mu.Unlock()
 	p.online = make(map[string]map[string]struct{})
 	p.channels = make(map[string]map[string]map[string]struct{})
+	p.conns = make(map[string]int)
 	for _, m := range members {
 		p.addLocked(m.AppKey, m.Uid, m.Channels)
+		// one member per socket → counting members is the connection count
+		p.conns[m.AppKey]++
 	}
 	return nil
 }
@@ -131,6 +144,27 @@ func (p *memoryPresence) Channels(prefix, appKey, pattern string) ([]string, err
 		}
 	}
 	return setToSlice(set), nil
+}
+
+// Stats aggregates per-app counts across all nodes: connection (socket) counts
+// are summed (exact — a socket lives on one node), while user counts are summed
+// from each node's distinct-uid count (approximate — a user connected to two
+// nodes is counted twice).
+func (p *memoryPresence) Stats(prefix string) (map[string]AppStat, error) {
+	replies, err := p.scatter(presenceQuery{Type: "stats"})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]AppStat)
+	for _, r := range replies {
+		for app, s := range r.Stats {
+			cur := out[app]
+			cur.Conns += s.Conns
+			cur.Users += s.Users
+			out[app] = cur
+		}
+	}
+	return out, nil
 }
 
 func (p *memoryPresence) scatterUids(q presenceQuery) ([]string, error) {
@@ -202,6 +236,17 @@ func (p *memoryPresence) handleQuery(m *nats.Msg) {
 		for ch := range p.channels[q.AppKey] {
 			if globMatch(q.Pattern, ch) {
 				reply.Channels = append(reply.Channels, ch)
+			}
+		}
+	case "stats":
+		// union of apps known from either map; report per-app conn + user counts
+		reply.Stats = make(map[string]appStatWire)
+		for app := range p.conns {
+			reply.Stats[app] = appStatWire{Conns: p.conns[app], Users: len(p.online[app])}
+		}
+		for app := range p.online {
+			if _, ok := reply.Stats[app]; !ok {
+				reply.Stats[app] = appStatWire{Conns: p.conns[app], Users: len(p.online[app])}
 			}
 		}
 	}

--- a/vendor/github.com/syhlion/redisocket.v2/presence.go
+++ b/vendor/github.com/syhlion/redisocket.v2/presence.go
@@ -14,6 +14,13 @@ type PresenceMember struct {
 	Channels []string
 }
 
+// AppStat is a per-app usage snapshot returned by Stats: Conns is the live
+// connection (socket) count, Users is the distinct-user (uid) count.
+type AppStat struct {
+	Conns int `json:"conns"`
+	Users int `json:"users"`
+}
+
 // Presence 抽象「在線/頻道成員」追蹤:誰在線、某頻道有誰、列頻道。
 // 現役為 Redis sorted-set 實作;NATS 後端將以 per-node 記憶體 + request/reply 取代,
 // 屆時連線層不需改動(只換注入的實作)。
@@ -28,6 +35,8 @@ type Presence interface {
 	Online(prefix, appKey string) ([]string, error)
 	// Channels 回傳某 app 符合 pattern 的頻道名。
 	Channels(prefix, appKey, pattern string) ([]string, error)
+	// Stats 回傳每個 app 的連線數 + 在線人數(全節點彙整)。
+	Stats(prefix string) (map[string]AppStat, error)
 	// Close 釋放資源(memoryPresence 退訂查詢主題;redisPresence 為 no-op)。
 	Close() error
 }
@@ -108,6 +117,30 @@ func (p *redisPresence) Online(prefix, appKey string) ([]string, error) {
 	nt := time.Now().Unix()
 	dt := nt - 120
 	return redis.Strings(conn.Do("ZRANGEBYSCORE", prefix+appKey+"@online", dt, nt))
+}
+
+// Stats reports per-app counts. The redis @online set is keyed by uid (deduped),
+// so socket count is not tracked; Conns and Users both report the distinct-user
+// count (best-effort — the NATS memoryPresence backend tracks them separately).
+func (p *redisPresence) Stats(prefix string) (map[string]AppStat, error) {
+	conn := p.pool.Get()
+	defer conn.Close()
+	keys, err := redis.Strings(conn.Do("keys", prefix+"*@online"))
+	if err != nil {
+		return nil, err
+	}
+	nt := time.Now().Unix()
+	dt := nt - 120
+	out := make(map[string]AppStat)
+	for _, k := range keys {
+		app := strings.TrimSuffix(strings.TrimPrefix(k, prefix), "@online")
+		n, err := redis.Int(conn.Do("ZCOUNT", k, dt, nt))
+		if err != nil {
+			continue
+		}
+		out[app] = AppStat{Conns: n, Users: n}
+	}
+	return out, nil
 }
 
 func (p *redisPresence) Channels(prefix, appKey, pattern string) ([]string, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,7 +88,7 @@ github.com/russross/blackfriday/v2
 github.com/shurcooL/sanitized_anchor_name
 # github.com/stretchr/testify v1.7.0
 ## explicit; go 1.13
-# github.com/syhlion/redisocket.v2 v1.0.1
+# github.com/syhlion/redisocket.v2 v1.1.0
 ## explicit; go 1.25.0
 github.com/syhlion/redisocket.v2
 # github.com/urfave/cli v1.22.10


### PR DESCRIPTION
PR 4 of the series. Adds cross-app observability on the master, backed by `redisocket.v2` **v1.1.0**'s new `Stats` scatter-gather ([redisocket PR #6](https://github.com/syhlion/redisocket.v2/pull/6)).

## Endpoints (master)
- `GET /v1/stats` → `{"apps":N,"connections":C,"users":U}` — totals across all apps
- `GET /v1/apps` → `[{"app","connections","users"}]` — per-app, sorted

**connections** are exact (summed sockets — each lives on one node); **users** are an approximate sum (a user connected to multiple nodes is counted per node). Counts refresh on each presence sync (`GUSHER_SCAN_INTERVAL`, default 30s).

## Verification
Against the real docker-compose stack:
- zero state → `/v1/stats` = `{"apps":0,"connections":0,"users":0}`, `/v1/apps` = `[]`
- one held WS connection (after a sync) → `/v1/stats` = `{"apps":1,"connections":1,"users":1}`, `/v1/apps` = `[{"app":"TEST","connections":1,"users":1}]`

The exact/approximate counting math is unit-tested upstream (`TestMemoryPresenceStatsCrossNode`). `go build`/`vet`/`gofmt` clean.

Feeds PR 5 (the `/ui` console's global overview section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)