### PR TITLE
feat(ui): add master /ui monitoring console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### [Added]
 
+- **Engineering console** (master): `GET /ui` — a single self-contained HTML page
+  (no build, no auth) showing master health, global connection/user totals, a
+  per-app breakdown, and per-channel online counts for an entered app_key, with
+  optional 3s auto-refresh. Mirrors gua's console; a probe + API-validation
+  surface, not an end-user product.
 - **Global observability endpoints** (master): `GET /v1/stats` (totals across all
   apps) and `GET /v1/apps` (per-app breakdown), each reporting **connections**
   (exact — summed sockets) and **users** (approximate — summed per-node distinct

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ protocol and [doc/api.md](./doc/api.md) for the REST API.
 
 - **Health**: `GET /healthz` (liveness) · `GET /readyz` (readiness — 200 only while
   NATS is connected).
+- **Console / stats**: the master serves a single-page console at `GET /ui` (global
+  connections/users + per-app channels) over `GET /v1/stats` and `GET /v1/apps`.
 - **NATS auth**: set `GUSHER_NATS_CREDS=/path/to/app.creds` for user credentials;
   use a `tls://` address (or NATS server config) for TLS. The client auto-reconnects.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -106,6 +106,8 @@ JWT 帶有 `gusher` claim——`{"app_key","user_id","channels"}`——以 **RS2
 
 - **健康檢查**：`GET /healthz`（liveness）· `GET /readyz`（readiness——只有在 NATS
   連線正常時才回 200）。
+- **Console / 統計**：master 在 `GET /ui` 提供單頁 console（全域連線數/人數 ＋ 逐 app
+  頻道），背後走 `GET /v1/stats` 與 `GET /v1/apps`。
 - **NATS 認證**：設定 `GUSHER_NATS_CREDS=/path/to/app.creds` 使用 user credentials；
   TLS 則用 `tls://` 位址（或在 NATS server 設定）。client 會自動重連。
 

--- a/cmd.go
+++ b/cmd.go
@@ -65,6 +65,7 @@ func master(c *cli.Context) {
 	r.HandleFunc("GET /healthz", Healthz())
 	r.HandleFunc("GET /readyz", Ready(nc))
 	r.HandleFunc("GET /version", Version(mc.Version))
+	r.HandleFunc("GET /ui", UI())
 
 	// global observability (across all apps)
 	r.HandleFunc("GET /v1/stats", GetGlobalStats(rsender))

--- a/doc/api.md
+++ b/doc/api.md
@@ -13,6 +13,18 @@ Request and response bodies are JSON.
 | GET | `/healthz` | liveness — `200 ok` while the process serves |
 | GET | `/readyz` | readiness — `200 ready` when NATS is connected, `503` otherwise |
 | GET | `/version` | build version string |
+| GET | `/ui` | master only — single-page engineering console (global stats + per-app channels) |
+
+## Master observability
+
+Counts refresh on each presence sync (`GUSHER_SCAN_INTERVAL`, default 30s).
+`connections` is exact; `users` is an approximate sum across nodes (a user
+connected to multiple nodes is counted per node).
+
+| Method | Path | Response |
+|---|---|---|
+| GET | `/v1/stats` | `{"apps":3,"connections":348,"users":312}` — totals across all apps |
+| GET | `/v1/apps` | `[{"app":"TEST","connections":120,"users":110}, ...]` — per-app, sorted |
 
 ## Slave API
 

--- a/ui.go
+++ b/ui.go
@@ -1,0 +1,75 @@
+package main
+
+import "net/http"
+
+// uiHTML is a single-page engineering console served by the master. It polls the
+// read-only observability endpoints — global stats, per-app breakdown, and (for
+// a given app_key) channels with their online counts. Not an end-user product —
+// a probe + API-validation surface for RD/ops, matching gua's console.
+const uiHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>gusher console</title>
+<style>
+ body{font:13px/1.4 monospace;margin:16px;background:#0b0e14;color:#c9d1d9}
+ h1{font-size:16px} h2{font-size:13px;color:#7ee787;margin:16px 0 6px}
+ table{border-collapse:collapse;width:100%;margin-bottom:8px}
+ td,th{border:1px solid #2d333b;padding:3px 6px;text-align:left;font-size:12px}
+ th{background:#161b22;color:#8b949e}
+ .ok{color:#3fb950} .bad{color:#f85149} .muted{color:#8b949e}
+ input,button{font:12px monospace;background:#161b22;color:#c9d1d9;border:1px solid #2d333b;padding:3px 6px}
+ #bar{margin-bottom:10px} b{color:#e6edf3}
+</style></head><body>
+<h1>gusher console <span class="muted" id="ver"></span> <span id="health"></span></h1>
+<div id="bar">app_key: <input id="app" placeholder="app key" size="16">
+ <button onclick="load()">load</button>
+ <button onclick="toggle()">auto-refresh: <span id="ar">off</span></button></div>
+<h2>global</h2><div id="global"></div>
+<h2>apps</h2><div id="apps"></div>
+<h2>channels <span class="muted" id="appname"></span></h2><div id="channels"></div>
+<script>
+let timer=null;
+const esc=s=>String(s==null?'':s).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+async function j(u){const r=await fetch(u);if(!r.ok)throw new Error(u+' '+r.status);return r.json();}
+async function ok(u){try{const r=await fetch(u);return r.ok;}catch(e){return false;}}
+function table(rows,cols){if(!rows||!rows.length)return '<div class="muted">(none)</div>';
+ let h='<table><tr>'+cols.map(c=>'<th>'+c[0]+'</th>').join('')+'</tr>';
+ for(const x of rows)h+='<tr>'+cols.map(c=>'<td>'+c[1](x)+'</td>').join('')+'</tr>';return h+'</table>';}
+async function load(){
+ try{document.getElementById('ver').textContent=await j('/version');}catch(e){}
+ // health row
+ const live=await ok('/healthz'), ready=await ok('/readyz');
+ document.getElementById('health').innerHTML=
+  '· master: '+(live?'<span class=ok>● healthy</span>':'<span class=bad>● down</span>')+
+  ' &nbsp; ready: '+(ready?'<span class=ok>● ok</span>':'<span class=bad>● not ready</span>');
+ // global totals
+ try{const s=await j('/v1/stats');
+  document.getElementById('global').innerHTML=
+   '<div>apps: <b>'+s.apps+'</b> &nbsp; connections: <b>'+s.connections+'</b>'+
+   ' &nbsp; online users: <b>'+s.users+'</b> <span class=muted>(users approx)</span></div>';
+ }catch(e){document.getElementById('global').innerHTML='<span class=bad>'+esc(e.message)+'</span>';}
+ // per-app breakdown
+ try{const apps=await j('/v1/apps');
+  document.getElementById('apps').innerHTML=table(apps,[['app',x=>esc(x.app)],
+   ['connections',x=>x.connections],['online users',x=>x.users]]);
+ }catch(e){document.getElementById('apps').innerHTML='<span class=bad>'+esc(e.message)+'</span>';}
+ // channels for the entered app_key
+ const g=document.getElementById('app').value.trim();
+ document.getElementById('appname').textContent=g?('('+g+')'):'';
+ if(!g){document.getElementById('channels').innerHTML='<div class=muted>enter an app_key</div>';return;}
+ try{const chs=await j('/v1/apps/'+encodeURIComponent(g)+'/channels');
+  const rows=await Promise.all((chs||[]).map(async ch=>{
+   let n='?';try{n=(await j('/v1/apps/'+encodeURIComponent(g)+'/channels/'+encodeURIComponent(ch)+'/users/count')).count;}catch(e){}
+   return {channel:ch,online:n};}));
+  document.getElementById('channels').innerHTML=table(rows,[['channel',x=>esc(x.channel)],['online',x=>x.online]]);
+ }catch(e){document.getElementById('channels').innerHTML='<span class=bad>'+esc(e.message)+'</span>';}
+}
+function toggle(){if(timer){clearInterval(timer);timer=null;document.getElementById('ar').textContent='off';}
+ else{timer=setInterval(load,3000);document.getElementById('ar').textContent='on';load();}}
+load();
+</script></body></html>`
+
+func UI() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(uiHTML))
+	}
+}


### PR DESCRIPTION
PR 5 (final) of the series. Adds a single-page engineering console on the master at `GET /ui`, mirroring gua's console — so gusher reaches parity (it already had REST + health + version + stats; this adds the observability UI you asked for).

## What it shows
- **master health** row (`/healthz`, `/readyz`)
- **global totals** (`/v1/stats`): apps, connections (exact), online users (approx)
- **per-app breakdown** (`/v1/apps`)
- **channels** for an entered `app_key` with per-channel online counts (`/v1/apps/{app}/channels` + `/channels/{ch}/users/count`)
- optional **3s auto-refresh**

Self-contained HTML/JS, no build step, no auth — a probe + API-validation surface for RD/ops, not an end-user product. Embedded the same way as gua's `ui.go`.

## Verification
Against the docker-compose stack: `GET /ui` → `200 text/html` (3779 bytes), and it references the live endpoints (`/version`, `/healthz`, `/readyz`, `/v1/stats`, `/v1/apps`, `/v1/apps/{app}/channels…`). The underlying endpoints were verified non-zero in PR #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)