### PR TITLE
chore(release): stamp v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [v3.0.0] - 2026-06-26
+
+> **Breaking**: HTTP API redesigned to a clean resource-oriented REST shape under
+> `/v1` (see below). No external consumers yet — hard cutover, no aliases.
+
 ### [Added]
 
 - **Engineering console** (master): `GET /ui` — a single self-contained HTML page


### PR DESCRIPTION
Stamps the modernization work as **v3.0.0** (breaking major bump from v2.0.0): clean resource-oriented REST API under `/v1` on stdlib net/http, global `/v1/stats` + `/v1/apps`, and the `/ui` console. Moves the CHANGELOG `[Unreleased]` block under `[v3.0.0]`. Tag pushed after merge → Drone builds `syhlion/gusher.cluster:3.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)