### PR TITLE
docs(example): add one-command realtime push demo

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,41 @@
+# gusher.cluster example — realtime push demo
+
+A one-command, self-contained demo: type a message on one side and watch it
+arrive **live** on the other over a WebSocket. It shows the whole path —
+backend publish → master → NATS → slave → browser — with no Redis and no setup.
+
+## Run
+
+From the repo root:
+
+```sh
+docker compose -f example/docker-compose.yml up --build
+```
+
+Then open **<http://localhost:8080>**.
+
+- **Left pane (backend → publish)** — type a message and hit *send*. The demo
+  backend proxies it to the master: `POST /v1/apps/TEST/channels/demo/messages`.
+- **Right pane (frontend → subscribe)** — a browser WebSocket to the slave
+  (`/v1/apps/TEST/ws`), subscribed to channel `demo`. Whatever you send on the
+  left pops up here instantly. Open a second tab to see the fan-out.
+
+## What's in the stack
+
+| Service | Role |
+|---|---|
+| `nats` | the only backend (bus + presence) |
+| `gusher-master` (`:7777`, internal) | publish/REST API — the demo proxies to it |
+| `gusher-slave` (`:8888`) | holds the WebSocket the browser connects to |
+| `demo` (`:8080`) | tiny stdlib Go backend: serves the page, signs a demo JWT, proxies publishes |
+
+## How auth works here
+
+gusher verifies a JWT (RS256) signed by **your** auth service. This demo reuses
+the repo's demo keypair (`test/key/`): the `demo` backend signs a token with the
+private key (so the browser never sees it) and master/slave verify with the
+matching public key. In production you'd swap in your own keys — see
+[../docs/KEYS.md](../docs/KEYS.md).
+
+> Demo only — no auth on the demo backend, fixed app/channel (`TEST`/`demo`).
+> For the full HTTP API see [../doc/api.md](../doc/api.md).

--- a/example/app/Dockerfile
+++ b/example/app/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY main.go .
+RUN go mod init gusher-example && CGO_ENABLED=0 go build -o /demo .
+
+FROM alpine:3.20
+WORKDIR /app
+COPY --from=build /demo ./demo
+COPY static ./static
+EXPOSE 8080
+ENTRYPOINT ["./demo"]

--- a/example/app/main.go
+++ b/example/app/main.go
@@ -1,0 +1,135 @@
+// Command demo is a tiny backend for the gusher.cluster example: it serves the
+// single-page UI, signs a demo JWT (so the browser never holds the private key),
+// and proxies publishes to the master (so the page stays same-origin / CORS-free).
+// Pure stdlib — no dependencies.
+package main
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+const (
+	appKey  = "TEST"
+	channel = "demo"
+)
+
+var privKey *rsa.PrivateKey
+
+func env(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	masterURL := env("MASTER_URL", "http://localhost:7777")
+	staticDir := env("STATIC_DIR", "static")
+	keyPath := env("PRIVATE_PEM", "/keys/private.pem")
+	addr := env("LISTEN", ":8080")
+
+	pk, err := loadPriv(keyPath)
+	if err != nil {
+		log.Fatalf("load private key: %v", err)
+	}
+	privKey = pk
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /", http.FileServer(http.Dir(staticDir)))
+
+	// /token signs a demo JWT for app=TEST, channel=demo and tells the page where
+	// the slave WebSocket lives (same host, port 8888).
+	mux.HandleFunc("GET /token", func(w http.ResponseWriter, r *http.Request) {
+		tok, err := signJWT()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{"token": tok, "app": appKey, "channel": channel, "wsPort": "8888"})
+	})
+
+	// /publish proxies a message to the master so the browser stays same-origin.
+	mux.HandleFunc("POST /publish", func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Message string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		body, _ := json.Marshal(map[string]any{"event": "message", "data": in.Message})
+		resp, err := http.Post(masterURL+"/v1/apps/"+appKey+"/channels/"+channel+"/messages",
+			"application/json", bytes.NewReader(body))
+		if err != nil {
+			http.Error(w, "publish failed: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	})
+
+	log.Printf("gusher example demo listening on %s (master=%s)", addr, masterURL)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+// signJWT builds an RS256 gusher JWT by hand (header.payload.signature) so the
+// demo needs no JWT library.
+func signJWT() (string, error) {
+	header := b64(`{"alg":"RS256","typ":"JWT"}`)
+	claims, _ := json.Marshal(map[string]any{
+		"gusher": map[string]any{
+			"app_key":  appKey,
+			"user_id":  "demo-user",
+			"channels": []string{channel},
+		},
+	})
+	signingInput := header + "." + b64(string(claims))
+	sum := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func b64(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+
+func loadPriv(path string) (*rsa.PrivateKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	blk, _ := pem.Decode(raw)
+	if blk == nil {
+		return nil, errors.New("no PEM block in key file")
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(blk.Bytes); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParsePKCS8PrivateKey(blk.Bytes); err == nil {
+		if rk, ok := k.(*rsa.PrivateKey); ok {
+			return rk, nil
+		}
+	}
+	return nil, errors.New("unsupported private key (need RSA PKCS1/PKCS8)")
+}

--- a/example/app/static/index.html
+++ b/example/app/static/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>gusher.cluster — realtime demo</title>
+<style>
+ :root{color-scheme:dark}
+ body{font:14px/1.5 system-ui,monospace;margin:0;background:#0b0e14;color:#c9d1d9}
+ header{padding:14px 20px;border-bottom:1px solid #2d333b}
+ header h1{font-size:18px;margin:0}
+ header .sub{color:#8b949e;font-size:13px}
+ .wrap{display:flex;gap:16px;padding:20px;flex-wrap:wrap}
+ .pane{flex:1;min-width:320px;border:1px solid #2d333b;border-radius:8px;background:#0d1117}
+ .pane h2{font-size:14px;margin:0;padding:10px 14px;border-bottom:1px solid #2d333b;color:#7ee787}
+ .pane .body{padding:14px}
+ input,button{font:14px system-ui;border:1px solid #2d333b;border-radius:6px;background:#161b22;color:#c9d1d9;padding:8px 10px}
+ button{background:#238636;border-color:#238636;color:#fff;cursor:pointer}
+ button:hover{background:#2ea043}
+ .row{display:flex;gap:8px}
+ .row input{flex:1}
+ #status{font-size:12px;color:#8b949e;margin-bottom:10px}
+ #status b.ok{color:#3fb950} #status b.bad{color:#f85149}
+ #log{list-style:none;margin:0;padding:0;max-height:46vh;overflow:auto}
+ #log li{padding:8px 10px;border:1px solid #21262d;border-radius:6px;margin-bottom:6px;background:#161b22}
+ #log li .t{color:#8b949e;font-size:11px}
+ #log li .m{color:#e6edf3;font-size:15px;word-break:break-word}
+ .muted{color:#8b949e}
+</style>
+</head>
+<body>
+<header>
+ <h1>gusher.cluster — realtime push demo</h1>
+ <div class="sub">type on the left (backend → master) · watch it arrive live on the right (slave → WebSocket)</div>
+</header>
+<div class="wrap">
+ <section class="pane">
+  <h2>① backend — publish</h2>
+  <div class="body">
+   <div class="muted" style="margin-bottom:10px">POST a message to channel <code>demo</code> (proxied to the master).</div>
+   <div class="row">
+    <input id="msg" placeholder="type a message…" autocomplete="off">
+    <button onclick="publish()">send</button>
+   </div>
+   <div id="pubstatus" class="muted" style="margin-top:8px"></div>
+  </div>
+ </section>
+ <section class="pane">
+  <h2>② frontend — subscribe</h2>
+  <div class="body">
+   <div id="status">connecting…</div>
+   <ul id="log"></ul>
+  </div>
+ </section>
+</div>
+<script>
+const $=id=>document.getElementById(id);
+const ts=()=>new Date().toLocaleTimeString();
+let ws=null, cfg=null;
+
+function setStatus(html){$('status').innerHTML=html;}
+
+async function connect(){
+ try{
+  cfg=await (await fetch('/token')).json();
+  const host=location.hostname, url='ws://'+host+':'+cfg.wsPort+'/v1/apps/'+cfg.app+'/ws?token='+cfg.token;
+  ws=new WebSocket(url);
+  ws.onopen=()=>{
+   setStatus('socket <b class=ok>open</b> · subscribing to <code>'+cfg.channel+'</code>…');
+   ws.send(JSON.stringify({event:'gusher.subscribe',data:{channel:cfg.channel}}));
+  };
+  ws.onmessage=ev=>{
+   let m; try{m=JSON.parse(ev.data);}catch(e){return;}
+   if(m.event==='gusher.subscribe_succeeded'){setStatus('subscribed to <code>'+cfg.channel+'</code> · <b class=ok>live</b>');return;}
+   if(m.event==='message'){addMsg(m.data);}
+  };
+  ws.onclose=()=>{setStatus('socket <b class=bad>closed</b> · retrying in 2s…');setTimeout(connect,2000);};
+  ws.onerror=()=>{setStatus('socket <b class=bad>error</b>');};
+ }catch(e){setStatus('<b class=bad>'+e.message+'</b> · retrying…');setTimeout(connect,2000);}
+}
+function addMsg(data){
+ const li=document.createElement('li');
+ li.innerHTML='<div class="t">'+ts()+'</div><div class="m"></div>';
+ li.querySelector('.m').textContent=typeof data==='string'?data:JSON.stringify(data);
+ $('log').prepend(li);
+}
+async function publish(){
+ const v=$('msg').value.trim(); if(!v)return;
+ $('msg').value='';
+ const r=await fetch('/publish',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:v})});
+ $('pubstatus').textContent=r.ok?('sent ✓ ('+ts()+')'):('send failed: '+r.status);
+}
+$('msg').addEventListener('keydown',e=>{if(e.key==='Enter')publish();});
+connect();
+</script>
+</body>
+</html>

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,56 @@
+# gusher.cluster realtime demo — nats + master + slave + a tiny demo backend.
+# Run from the repo root:
+#   docker compose -f example/docker-compose.yml up --build
+# then open http://localhost:8080
+#
+# Reuses the repo's demo RSA keypair (test/key/{private,public}.pem): the demo
+# backend signs JWTs with the private key; master/slave verify with the public key.
+
+services:
+  nats:
+    image: nats:2.10-alpine
+    command: ["-js"]
+
+  gusher-master:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: gusher.cluster:example
+    command: ["master"]
+    environment:
+      GUSHER_NATS_ADDR: "nats://nats:4222"
+      GUSHER_MASTER_API_LISTEN: ":7777"
+      GUSHER_PUBLIC_PEM_FILE: "/keys/public.pem"
+      GUSHER_LOG_OUTPUT: "stdout"
+      GUSHER_LOG_FORMAT: "json"
+    volumes:
+      - ../test/key/public.pem:/keys/public.pem:ro
+    depends_on: [nats]
+
+  gusher-slave:
+    image: gusher.cluster:example
+    command: ["slave"]
+    environment:
+      GUSHER_NATS_ADDR: "nats://nats:4222"
+      GUSHER_API_LISTEN: ":8888"
+      GUSHER_PUBLIC_PEM_FILE: "/keys/public.pem"
+      GUSHER_LOG_OUTPUT: "stdout"
+      GUSHER_LOG_FORMAT: "json"
+    volumes:
+      - ../test/key/public.pem:/keys/public.pem:ro
+    ports:
+      - "8888:8888" # browser opens the WebSocket here
+    depends_on: [nats, gusher-master]
+
+  demo:
+    build:
+      context: ./app
+    environment:
+      MASTER_URL: "http://gusher-master:7777"
+      PRIVATE_PEM: "/keys/private.pem"
+      LISTEN: ":8080"
+    volumes:
+      - ../test/key/private.pem:/keys/private.pem:ro
+    ports:
+      - "8080:8080" # the demo UI
+    depends_on: [gusher-master, gusher-slave]


### PR DESCRIPTION
Adds `example/` — a self-contained, one-command interactive demo of the realtime push path.

```sh
docker compose -f example/docker-compose.yml up --build   # then open http://localhost:8080
```

- **Left pane** (backend → publish): type a message → demo backend proxies to master `POST /v1/apps/TEST/channels/demo/messages`.
- **Right pane** (frontend → subscribe): browser WebSocket to the slave `/v1/apps/TEST/ws`, subscribed to `demo` — messages arrive live. Open a 2nd tab to see fan-out.

**Stack**: nats + gusher-master + gusher-slave + a tiny **stdlib-only** Go demo backend (`example/app/main.go`) that serves the page, **signs a demo JWT by hand** (RS256, reusing `test/key/` so the browser never holds the key), and proxies publishes (same-origin → no CORS). Single-page split UI, vanilla JS, no build step.

**Verified** against the running stack: `/token` issues a valid JWT, subscribe → `subscribe_succeeded`, publish `hello-demo` → socket receives `{"channel":"demo","event":"message","data":"hello-demo"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)