### PR TITLE
docs: link the runnable example/ demo from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Output is selectable and rotated, via env:
 
 ## Docs
 
+- [example/](example/) — **runnable demo**: type on a backend, watch it arrive live on a frontend (one `docker compose` command)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — architecture, NATS bus/presence, evolution from Redis (with diagrams)
 - [doc/protocal.md](./doc/protocal.md) — WebSocket protocol
 - [doc/api.md](./doc/api.md) — REST API

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -124,6 +124,7 @@ JWT 帶有 `gusher` claim——`{"app_key","user_id","channels"}`——以 **RS2
 
 ## 文件
 
+- [example/](example/) — **可直接跑的 demo**：在後端打字、前端即時看到（一行 `docker compose` 啟動）
 - [docs/ARCHITECTURE.zh-TW.md](docs/ARCHITECTURE.zh-TW.md) — 架構、NATS 匯流排/presence、從 Redis 的演進（含圖）
 - [doc/protocal.md](./doc/protocal.md) — WebSocket 協定
 - [doc/api.md](./doc/api.md) — REST API


### PR DESCRIPTION
Adds a Docs-section link (EN + zh) pointing at the new `example/` realtime push demo, so people can find it. The standalone walkthrough lives in `example/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)