### PR TITLE
ci(drone): cut PR/branch noise — ref trigger + gate docker/notify

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,14 @@
 kind: pipeline
 name: default
 
+# Only build master pushes, tags, and pull requests — not every feature/docs
+# branch push. ref-based so tag builds are never filtered out by a branch rule.
+trigger:
+  ref:
+    - refs/heads/master
+    - refs/tags/**
+    - refs/pull/**
+
 steps:
 - name: test
   image: golang:1.25
@@ -22,6 +30,10 @@ steps:
         from_secret: docker_account
     password:
         from_secret: docker_password
+  when:
+    event:
+    - push
+    - tag
 - name: build
   image: golang
   commands:
@@ -58,6 +70,9 @@ steps:
     to:
         from_secret: bot_to
   when:
+    event:
+    - push
+    - tag
     status:
     - failure
     - success


### PR DESCRIPTION
Roots out the false-failure / queue noise:

- **ref-based `trigger`** (`refs/heads/master` + `refs/tags/**` + `refs/pull/**`) — feature/docs branch pushes no longer spawn (clone-failing) builds; eases the capacity=1 queue. Uses `ref` rather than `branch: master` so **tag builds are never filtered out** (a branch rule can silently drop tag events depending on Drone version).
- **docker** step gated to `event: [push, tag]` — no image push attempt on PRs (where secrets may be missing → false fail).
- **notify** gated to `event: [push, tag]` — PRs no longer fire Telegram alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)