### PR TITLE
ci: stamp release version into the image; pin release-build Go to 1.25

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,8 @@ steps:
     dockerfile: docker/Dockerfile
     auto_tag: true
     purge: true
+    build_args:
+      - VERSION=${DRONE_SEMVER}
     username:
         from_secret: docker_account
     password:
@@ -36,7 +38,7 @@ steps:
     - push
     - tag
 - name: build
-  image: golang
+  image: golang:1.25
   commands:
   - git fetch --tags
   - make build/linux_amd64.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,12 @@
 # build stage（本地原始碼 + vendor;Go 1.25，無 redis、NATS 後端）
 FROM golang:1.25-alpine AS builder
 WORKDIR /app
+# VERSION is stamped into main.version (shown by GET /version); passed from CI as
+# the release tag, empty for non-tag (:latest) builds.
+ARG VERSION
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor \
-    -ldflags "-X main.name=gusher" -o /gusher.cluster .
+    -ldflags "-X main.name=gusher -X main.version=${VERSION}" -o /gusher.cluster .
 
 # final stage
 FROM alpine:3.20


### PR DESCRIPTION
Two CI/CD fixes from the review:

1. **Image `/version` was empty** — the Dockerfile didn't stamp `main.version`, so `syhlion/gusher.cluster:3.0.0` reported no version. Now `ARG VERSION` → `-ldflags -X main.version`, fed by the docker step's `build_args: VERSION=${DRONE_SEMVER}` (→ `3.0.0` on a tag build, empty on `:latest`).
2. **Release `build` step used unpinned `image: golang`** (latest) — pinned to `golang:1.25` to match `test` and keep release binaries reproducible.

Verified: `docker build --build-arg VERSION=9.9.9-test` → `gusher --version` prints `gusher version 9.9.9-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)